### PR TITLE
Correcting variable expansion for docker dev

### DIFF
--- a/modules/docker/docker
+++ b/modules/docker/docker
@@ -41,7 +41,7 @@ function docker() {
 	;;
 	dev)
 		shift
-		command docker run -t -i -v "$PWD:/docker" --workdir=/docker "$@"
+		command docker run -t -i -v "$PWD:/docker" --workdir=/docker "${(z)@}"
 	;;
         enter)
 		if [ -z "$3" ]; then


### PR DESCRIPTION
Correcting the variable expansion the `docker dev` command uses so that things like `docker dev $DOCKER_DEV imagename` will work properly.  Without this, it could possibly interpret mounts and other options that might be saved in `$DOCKER_DEV`.
